### PR TITLE
Improve reusable test and deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
 name: Deploy to GitHub Pages
 
 on:
-  workflow_run:
-    workflows: ["Tests"]
-    types: [completed]
+  push:
     branches: [main]
   workflow_dispatch:
 
@@ -15,25 +13,38 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  tests:
+    name: Tests
+    uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
+
   build:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    name: Build Pages artifact
+    needs: tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - run: npm ci
 
-      - run: npx ng build --base-href /
+      - run: npm run build -- --base-href /
 
       - name: Copy index.html to 404.html for SPA routing
         run: cp dist/veerajajani2022.com/browser/index.html dist/veerajajani2022.com/browser/404.html
+
+      - uses: actions/configure-pages@v5
 
       - uses: actions/upload-pages-artifact@v5
         with:
@@ -42,7 +53,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,55 +2,71 @@ name: Tests
 
 on:
   pull_request:
-  push:
-    branches: [main]
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     name: Build & Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - run: npm ci
 
       - name: Build (type check + Angular production build)
-        run: npx ng build --base-href /
+        run: npm run build -- --base-href /
 
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - run: npm ci
 
       - name: Run unit tests
-        run: npx ng test --watch=false --browsers=ChromeHeadless
+        run: npm test -- --watch=false --browsers=ChromeHeadless
 
   e2e:
     name: Playwright Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - run: npm ci
 


### PR DESCRIPTION
Updates test.yml to support workflow_call while keeping pull_request and manual runs. Updates deploy.yml to run on push to main or manual dispatch, call the reusable Tests workflow with needs, then build and deploy GitHub Pages. Also moves CI to Node 24 and adds checkout credential hardening, cache dependency paths, configure-pages, and job timeouts. Verified with npm run build -- --base-href /, npm test -- --watch=false --browsers=ChromeHeadless, npx playwright test --reporter=line, and YAML parsing.