### PR TITLE
Bump actions/configure-pages to v6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Copy index.html to 404.html for SPA routing
         run: cp dist/veerajajani2022.com/browser/index.html dist/veerajajani2022.com/browser/404.html
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
       - uses: actions/upload-pages-artifact@v5
         with:


### PR DESCRIPTION
## Summary
- bump actions/configure-pages from v5 to v6 in the Pages deploy workflow

## Testing
- not run (GitHub Actions workflow change only)